### PR TITLE
luzer: fix parsing command-line flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix searching Clang RT.
 - Stack overflow due to recursive traceback calls.
 - Fix a crash due to incorrect `argv` building (#13).
+- Fix parsing command-line flags (#23).

--- a/luzer/init.lua
+++ b/luzer/init.lua
@@ -52,10 +52,12 @@ return {
     Fuzz = Fuzz,
     FuzzedDataProvider = luzer_impl.FuzzedDataProvider,
 
-    _LLVM_VERSION = luzer_impl._LLVM_VERSION,
-    _LUA_VERSION = luzer_impl._LUA_VERSION,
-    _LUZER_VERSION = luzer_impl._LUZER_VERSION,
+    _internal = {
+        LLVM_VERSION = luzer_impl._LLVM_VERSION,
+        LUA_VERSION = luzer_impl._LUA_VERSION,
+        LUZER_VERSION = luzer_impl._LUZER_VERSION,
 
-    _set_custom_mutator = luzer_impl._set_custom_mutator,
-    _mutate = luzer_impl._mutate,
+        set_custom_mutator = luzer_impl._set_custom_mutator,
+        mutate = luzer_impl._mutate,
+    }
 }

--- a/luzer/init.lua
+++ b/luzer/init.lua
@@ -14,7 +14,7 @@ end
 --
 -- 1. https://llvm.org/docs/LibFuzzer.html#options
 local function parse_flag(str)
-    local flag_name, flag_val = string.match(str, "-([%l%p]+)=(%w+)")
+    local flag_name, flag_val = string.match(str, "-([%w_]+)=(.+)")
     if not flag_name or
        not flag_val then
         error(("bad flag: %s"):format(str))
@@ -59,5 +59,6 @@ return {
 
         set_custom_mutator = luzer_impl._set_custom_mutator,
         mutate = luzer_impl._mutate,
+        parse_flag = parse_flag,
     }
 }

--- a/luzer/tests/test_unit.lua
+++ b/luzer/tests/test_unit.lua
@@ -199,4 +199,22 @@ assert(luzer_custom_mutator ~= nil)
 -- luzer._internal.mutate(buf, #buf, #buf, math.random(1, 10)) -- TODO
 luzer_custom_mutator = nil -- Clean up.
 
+-- luzer._internal.parse_flag()
+local flag_testcases = {
+    { "dict", "/tmp/lua.dict" },
+    { "help", "1" },
+    { "rss_limit_mb", "2048" },
+    { "runs", "-1" },
+}
+for _, testcase in ipairs(flag_testcases) do
+    local name = testcase[1]
+    local val = testcase[2]
+    -- libFuzzer flags are strictly in form `-flag=value`.
+    local flag = ("-%s=%s"):format(name, val)
+    -- Expected a table with `name` and `value`.
+    res = { luzer._internal.parse_flag(flag) }
+    assert(name == res[1], ("expected %s"):format(name))
+    assert(val == res[2], ("expected %s"):format(val))
+end
+
 print("Success!")

--- a/luzer/tests/test_unit.lua
+++ b/luzer/tests/test_unit.lua
@@ -7,10 +7,9 @@ end
 
 debug.sethook(trace, "l")
 
--- luzer._LUZER_VERSION
-assert(type(luzer._LUZER_VERSION) == "string")
-assert(type(luzer._LLVM_VERSION) == "string")
-assert(type(luzer._LUA_VERSION) == "string")
+assert(type(luzer._internal.LUZER_VERSION) == "string")
+assert(type(luzer._internal.LLVM_VERSION) == "string")
+assert(type(luzer._internal.LUA_VERSION) == "string")
 
 local ok
 local err
@@ -185,19 +184,19 @@ local function custom_mutator(data, size, max_size, seed)
     return data
 end
 
--- luzer._set_custom_mutator()
+-- luzer._internal.set_custom_mutator()
 assert(luzer_custom_mutator == nil)
-luzer._set_custom_mutator(custom_mutator)
+luzer._internal.set_custom_mutator(custom_mutator)
 assert(luzer_custom_mutator ~= nil)
 assert(type(luzer_custom_mutator) == "function")
 local buf = "data"
 assert(luzer_custom_mutator(buf, #buf, #buf, math.random(1, 10)) == buf)
 luzer_custom_mutator = nil -- Clean up.
 
--- luzer._mutate()
-luzer._set_custom_mutator(custom_mutator)
+-- luzer._internal.mutate()
+luzer._internal.set_custom_mutator(custom_mutator)
 assert(luzer_custom_mutator ~= nil)
--- luzer._mutate(buf, #buf, #buf, math.random(1, 10)) -- TODO
+-- luzer._internal.mutate(buf, #buf, #buf, math.random(1, 10)) -- TODO
 luzer_custom_mutator = nil -- Clean up.
 
 print("Success!")


### PR DESCRIPTION
The patch fixes a problem with incorrect parsing command-line flags and adds a tests for the function `parse_flag()`.

Fixes #23