### PR TITLE
luzer: initialize FDP metatable only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stack overflow due to recursive traceback calls.
 - Fix a crash due to incorrect `argv` building (#13).
 - Fix parsing command-line flags (#23).
+- Multiple initialization of the FDP metatable.

--- a/luzer/fuzzed_data_provider.h
+++ b/luzer/fuzzed_data_provider.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+	void fdp_metatable_init(lua_State *L);
 	int luaL_fuzzed_data_provider(lua_State *L);
 #ifdef __cplusplus
 } /* extern "C" */

--- a/luzer/luzer.c
+++ b/luzer/luzer.c
@@ -462,5 +462,7 @@ int luaopen_luzer_impl(lua_State *L)
 	lua_pushstring(L, LUA_RELEASE);
 	lua_rawset(L, -3);
 
+	fdp_metatable_init(L);
+
 	return 1;
 }


### PR DESCRIPTION
The FDP metatable is recreating each time when we initialize the FDP object. It increases the GC consumption and makes the code less JIT-friendly since traces are exited by the guard on the FDP methods objects that checked the exact pointer of the `GCobj` which is new for any new FDP provider.

This patch fixes that by initializing the metatable only once on the luzer library loading.