### PR TITLE
Fix luzer module import: install "init.lua" file to module-named directory

### DIFF
--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -67,5 +67,5 @@ install(
 
 install(
   FILES ${CMAKE_CURRENT_SOURCE_DIR}/init.lua
-  DESTINATION "${CMAKE_LIBDIR}/"
+  DESTINATION "${CMAKE_LIBDIR}/luzer/"
 )


### PR DESCRIPTION
Hello!
This probably fixes [i#27](https://github.com/ligurio/luzer/issues/27)