### PR TITLE
luzer: disable parasite instrumentation

### DIFF
--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LUZER_SOURCES luzer.c
 add_library(luzer_impl SHARED ${LUZER_SOURCES})
 target_include_directories(luzer_impl PRIVATE
     ${LUA_INCLUDE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(luzer_impl PRIVATE

--- a/luzer/compat.c
+++ b/luzer/compat.c
@@ -1,6 +1,7 @@
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
+#include "macros.h"
 
 /*
  * PUC-Rio Lua uses `lconfig_h` as include guard for `luaconf.h`,
@@ -14,7 +15,7 @@
 
 #if !defined(LUA_VERSION_NUM) || (LUA_VERSION_NUM == 501 && !defined(IS_LUAJIT))
 
-static int
+NO_SANITIZE static int
 countlevels(lua_State *L) {
 	lua_Debug ar;
 	int li = 1, le = 1;
@@ -32,7 +33,7 @@ countlevels(lua_State *L) {
 	return le - 1;
 }
 
-static int
+NO_SANITIZE static int
 findfield(lua_State *L, int objidx, int level) {
 	if (level == 0 || !lua_istable(L, -1))
 		/* Not found. */
@@ -68,14 +69,14 @@ findfield(lua_State *L, int objidx, int level) {
 	return 0;
 }
 
-int
+NO_SANITIZE int
 lua_absindex(lua_State *L, int i) {
 	if (i < 0 && i > LUA_REGISTRYINDEX)
 		i += lua_gettop(L) + 1;
 	return i;
 }
 
-void
+NO_SANITIZE void
 lua_copy(lua_State *L, int from, int to) {
 	int abs_to = lua_absindex(L, to);
 	luaL_checkstack(L, 1, "not enough stack slots");
@@ -83,7 +84,7 @@ lua_copy(lua_State *L, int from, int to) {
 	lua_replace(L, abs_to);
 }
 
-static int
+NO_SANITIZE static int
 pushglobalfuncname(lua_State *L, lua_Debug *ar) {
 	int top = lua_gettop(L);
 	/* Push function. */
@@ -103,7 +104,7 @@ pushglobalfuncname(lua_State *L, lua_Debug *ar) {
 	}
 }
 
-static void
+NO_SANITIZE static void
 pushfuncname(lua_State *L, lua_Debug *ar) {
 	/* Is there a name? */
 	if (*ar->namewhat != '\0')
@@ -128,7 +129,7 @@ pushfuncname(lua_State *L, lua_Debug *ar) {
 /* Size of the second part of the stack. */
 #define LEVELS2 10
 
-void
+NO_SANITIZE void
 luaL_traceback(lua_State *L, lua_State *L1,
 			   const char *msg, int level) {
 	lua_Debug ar;

--- a/luzer/fuzzed_data_provider.cc
+++ b/luzer/fuzzed_data_provider.cc
@@ -35,7 +35,7 @@ typedef struct {
 } lua_userdata_t;
 
 /* Consumes a string from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_string(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -52,7 +52,7 @@ luaL_consume_string(lua_State *L)
 }
 
 /* Consumes a table with specified number of strings from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_strings(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -78,7 +78,7 @@ luaL_consume_strings(lua_State *L)
 }
 
 /* Consumes a boolean from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_boolean(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -93,7 +93,7 @@ luaL_consume_boolean(lua_State *L)
 }
 
 /* Consumes a table with specified number of booleans from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_booleans(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -114,7 +114,7 @@ luaL_consume_booleans(lua_State *L)
 }
 
 /* Consumes a float from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_number(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -133,7 +133,7 @@ luaL_consume_number(lua_State *L)
 }
 
 /* Consumes a table with specified number of numbers from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_numbers(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -159,7 +159,7 @@ luaL_consume_numbers(lua_State *L)
 
 /* Consumes an arbitrary int or an int between min and max from the fuzzer
    input. */
-static int
+NO_SANITIZE static int
 luaL_consume_integer(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -178,7 +178,7 @@ luaL_consume_integer(lua_State *L)
 }
 
 /* Consumes an int array from the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_consume_integers(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -202,7 +202,7 @@ luaL_consume_integers(lua_State *L)
 	return 1;
 }
 
-static int
+NO_SANITIZE static int
 luaL_consume_probability(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -217,7 +217,7 @@ luaL_consume_probability(lua_State *L)
 }
 
 /* Returns the number of unconsumed bytes in the fuzzer input. */
-static int
+NO_SANITIZE static int
 luaL_remaining_bytes(lua_State *L)
 {
 	lua_userdata_t *lfdp;
@@ -231,7 +231,7 @@ luaL_remaining_bytes(lua_State *L)
 	return 1;
 }
 
-static int close(lua_State *L) {
+NO_SANITIZE static int close(lua_State *L) {
 	lua_userdata_t *lfdp;
 	lfdp = (lua_userdata_t *)luaL_checkudata(L, 1, FDP_LUA_UDATA_NAME);
 	delete lfdp->fdp;
@@ -239,7 +239,7 @@ static int close(lua_State *L) {
 	return 0;
 }
 
-static int tostring(lua_State *L) {
+NO_SANITIZE static int tostring(lua_State *L) {
 	lua_pushstring(L, "FuzzedDataProvider");
 	return 1;
 }
@@ -266,7 +266,7 @@ const luaL_Reg methods[] =
  * friendly. `luaL_fuzzed_data_provider()` is called in the loop inside
  * `LLVMFuzzerRunDriver()`.
  */
-void
+NO_SANITIZE void
 fdp_metatable_init(lua_State *L)
 {
 	luaL_newmetatable(L, FDP_LUA_UDATA_NAME);
@@ -280,7 +280,7 @@ fdp_metatable_init(lua_State *L)
 	lua_pop(L, 1); /* Remove the metatable from the stack. */
 }
 
-int
+NO_SANITIZE int
 luaL_fuzzed_data_provider(lua_State *L)
 {
 	int index = lua_gettop(L);

--- a/luzer/luzer.c
+++ b/luzer/luzer.c
@@ -34,13 +34,13 @@
 
 static lua_State *LL;
 
-static void
+NO_SANITIZE static void
 set_global_lua_state(lua_State *L)
 {
 	LL = L;
 }
 
-lua_State *
+NO_SANITIZE lua_State *
 get_global_lua_state(void)
 {
 	if (!LL) {
@@ -125,7 +125,7 @@ get_coverage_symbols_location(void) {
 	return (dl_info.dli_fname);
 }
 
-void
+NO_SANITIZE void
 init(void)
 {
 	if (!&LLVMFuzzerRunDriver) {
@@ -144,7 +144,7 @@ init(void)
 	}
 }
 
-static void
+NO_SANITIZE static void
 sig_handler(int sig)
 {
 	switch (sig) {
@@ -441,7 +441,8 @@ static const struct luaL_Reg Module[] = {
 	{ NULL, NULL }
 };
 
-int luaopen_luzer_impl(lua_State *L)
+NO_SANITIZE int
+luaopen_luzer_impl(lua_State *L)
 {
 	init();
 

--- a/luzer/tracer.c
+++ b/luzer/tracer.c
@@ -43,7 +43,8 @@ _trace_branch(uint64_t idx)
 	increment_counter(idx);
 }
 
-static inline unsigned int lhash(const char *key, size_t offset)
+NO_SANITIZE static inline unsigned int
+lhash(const char *key, size_t offset)
 {
 	const char *const last = &key[strlen(key) - 1];
 	uint32_t h = LHASH_INIT;
@@ -63,7 +64,8 @@ static inline unsigned int lhash(const char *key, size_t offset)
  * https://github.com/lunarmodules/luacov/blob/master/src/luacov/runner.lua#L102-L117
  * https://github.com/lunarmodules/luacov/blob/78f3d5058c65f9712e6c50a0072ad8160db4d00e/src/luacov/runner.lua#L439-L450
  */
-void debug_hook(lua_State *L, lua_Debug *ar)
+NO_SANITIZE void
+debug_hook(lua_State *L, lua_Debug *ar)
 {
 	lua_getinfo(L, "Sln", ar);
 	if (ar && ar->source && ar->currentline) {

--- a/luzer/version.c
+++ b/luzer/version.c
@@ -1,7 +1,11 @@
-const char *llvm_version_string(void) {
+#include "macros.h"
+
+NO_SANITIZE const char *
+llvm_version_string(void) {
 	return "@LLVM_VERSION@";
 }
 
-const char *luzer_version_string(void) {
+NO_SANITIZE const char *
+luzer_version_string(void) {
 	return "@CMAKE_PROJECT_VERSION@";
 }


### PR DESCRIPTION
Follows up commit f37950549bca ("luzer: disable instrumentation of internal functions").

Follows up #11