### PR TITLE
luzer: fix segmentation fault on Lua tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running with libFuzzer option `-jobs` (#32).
 - Integer overflow in `consume_integer()` and `consume_integers()`
   functions (#29).
+- Segmentation fault on tracing Lua source code (#18).

--- a/luzer/counters.c
+++ b/luzer/counters.c
@@ -22,15 +22,15 @@ void __sanitizer_cov_pcs_init(uint8_t* pcs_beg, uint8_t* pcs_end);
 } /* extern "C" */
 #endif
 
-static const int kDefaultNumCounters = 1 << 20;
+static const size_t kDefaultNumCounters = 1 << 20;
 
 // Number of counters requested by Lua instrumentation.
-int counter_index = 0;
+size_t counter_index = 0;
 // Number of counters given to Libfuzzer.
-int counter_index_registered = 0;
+size_t counter_index_registered = 0;
 // Maximum number of counters and pctable entries that may be reserved and also
 // the number that are allocated.
-int max_counters = 0;
+size_t max_counters = 0;
 // Counter Allocations. These are allocated once, before __sanitize_... are
 // called and can only be deallocated by test_only_reset_counters.
 unsigned char* counters = NULL;
@@ -51,21 +51,21 @@ test_only_reset_counters(void) {
 	counter_index_registered = 0;
 }
 
-NO_SANITIZE int
-reserve_counters(int counters) {
-	int ret = counter_index;
-	counter_index += counters;
+NO_SANITIZE size_t
+reserve_counters(size_t amount) {
+	size_t ret = counter_index;
+	counter_index += amount;
 	return ret;
 }
 
-NO_SANITIZE int
+NO_SANITIZE size_t
 reserve_counter(void)
 {
 	return counter_index++;
 }
 
 NO_SANITIZE void
-increment_counter(int counter_index)
+increment_counter(size_t index)
 {
 	if (counters != NULL && pctable != NULL) {
 		// `counters` is an allocation of length `max_counters`. If we reserve more
@@ -76,7 +76,7 @@ increment_counter(int counter_index)
 }
 
 NO_SANITIZE void
-set_max_counters(int max)
+set_max_counters(size_t max)
 {
 	if (counters != NULL && pctable != NULL) {
 		fprintf(stderr, "Internal error: attempt to set max number of counters after "
@@ -89,7 +89,7 @@ set_max_counters(int max)
 	max_counters = max;
 }
 
-NO_SANITIZE int
+NO_SANITIZE size_t
 get_max_counters(void)
 {
 	return max_counters;
@@ -122,7 +122,7 @@ allocate_counters_and_pcs(void) {
 		}
 	}
 
-	const int next_index = MIN(counter_index, max_counters);
+	const size_t next_index = MIN(counter_index, max_counters);
 	if (counter_index_registered >= next_index) {
 		// There are no counters to pass. Perhaps because we've reserved more than
 		// max_counters, or because no counters have been reserved since this was

--- a/luzer/counters.h
+++ b/luzer/counters.h
@@ -8,21 +8,21 @@ struct PCTableEntry {
 
 // Sets the global number of counters.
 // Must not be called after InitializeCountersWithLLVM is called.
-void set_max_counters(int max);
+void set_max_counters(size_t max);
 
 // Returns the maximum number of allocatable luzer counters. If more than this
 // many counters are reserved, luzer reuses counters, lowering fuzz quality.
-int get_max_counters(void);
+size_t get_max_counters(void);
 
 // Returns a new counter index.
-int reserve_counter(void);
+size_t reserve_counter(void);
 // Reserves a number of counters with contiguous indices, and returns the first
 // index.
-int reserve_counters(int counters);
+size_t reserve_counters(size_t amount);
 
 // Increments a counter at the given index. If more than the maximum number of
 // counters has been reserved, reuse counters.
-void increment_counter(int counter_index);
+void increment_counter(size_t index);
 
 typedef struct counter_and_pc_table_range {
 	unsigned char* counters_start;

--- a/luzer/macros.h
+++ b/luzer/macros.h
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <stdbool.h>
 
+#define UNUSED(x) (void)(x)
+
 #ifdef DEBUG
 #define DEBUG_PRINT(...) do{ fprintf( stderr, __VA_ARGS__ ); } while( false )
 #else

--- a/luzer/tracer.c
+++ b/luzer/tracer.c
@@ -27,8 +27,6 @@
 #include "counters.h"
 #include "macros.h"
 
-#define UNUSED(x) (void)(x)
-
 /**
  * From afl-python
  * https://github.com/jwilk/python-afl/blob/8df6bfefac5de78761254bf5d7724e0a52d254f5/afl.pyx#L74-L87
@@ -70,9 +68,6 @@ debug_hook(lua_State *L, lua_Debug *ar)
 	lua_getinfo(L, "Sln", ar);
 	if (ar && ar->source && ar->currentline) {
 		const unsigned int new_location = lhash(ar->source, ar->currentline);
-		UNUSED(new_location);
-		// Lua tracing is temporarily disabled due to segfaults,
-		// see https://github.com/ligurio/luzer/issues/18.
-		/* _trace_branch(new_location); */
+		_trace_branch(new_location);
 	}
 }


### PR DESCRIPTION
The patch enables `debug.sethook()` that was disabled in commit fc85bea65249 ("luzer: disable Lua tracing") and fixes integer overflow in PC counters, this can lead to
segmentation fault. The patch also renames argument `counters` to `amount` in the function `reserve_counters()` and renames `counter_index` to `index` in the function `increment_counter()`.

Fixes #18