### PR TITLE
luzer: fix running with -jobs option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple initialization of the FDP metatable.
 - Building the project using luarocks (#4).
 - Installation using luarocks (#27).
+- Running with libFuzzer option `-jobs` (#32).

--- a/luzer/init.lua
+++ b/luzer/init.lua
@@ -43,9 +43,21 @@ local function build_flags(arg, func_args)
     return flags
 end
 
+local function progname(argv)
+    -- arg[-1] is guaranteed to be not nil.
+    local idx = -2
+    while argv[idx] do
+        idx = idx - 1
+    end
+    return argv[idx + 1]
+end
+
 local function Fuzz(test_one_input, custom_mutator, func_args)
     local flags = build_flags(arg, func_args)
-    luzer_impl.Fuzz(test_one_input, custom_mutator, flags)
+    local test_path = arg[0]
+    local lua_bin = progname(arg)
+    local test_cmd = ("%s %s"):format(lua_bin, test_path)
+    luzer_impl.Fuzz(test_one_input, custom_mutator, flags, test_cmd)
 end
 
 return {

--- a/luzer/luzer.c
+++ b/luzer/luzer.c
@@ -336,7 +336,7 @@ NO_SANITIZE static void
 free_argv(int argc, char **argv)
 {
 	/* Free allocated argv strings and the buffer. */
-	for (int i = 1; i < argc; i++)
+	for (int i = 0; i < argc; i++)
 		free(argv[i]);
 	free(argv);
 }
@@ -344,6 +344,9 @@ free_argv(int argc, char **argv)
 NO_SANITIZE static int
 luaL_fuzz(lua_State *L)
 {
+	const char *str = luaL_checkstring(L, -1);
+	lua_pop(L, 1);
+	char *argv_0 = strdup(str);
 	if (lua_istable(L, -1) == 0) {
 		luaL_error(L, "opts is not a table");
 	}
@@ -353,7 +356,7 @@ luaL_fuzz(lua_State *L)
 	if (!argv)
 		luaL_error(L, "not enough memory");
 
-	argv[0] = "<test name>";
+	argv[0] = argv_0;
 	const char *corpus_path = NULL;
 
 	/* First key to start iteration. */

--- a/luzer/tests/CMakeLists.txt
+++ b/luzer/tests/CMakeLists.txt
@@ -65,6 +65,18 @@ set_tests_properties(luzer_options_seed_via_option_test PROPERTIES
 )
 
 add_test(
+  NAME luzer_options_jobs_test
+  COMMAND ${LUA_EXECUTABLE} -e "a = 1"
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_options_2.lua
+          -runs=10 -jobs=5
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(luzer_options_jobs_test PROPERTIES
+  ENVIRONMENT "LUA_CPATH=${LUA_CPATH};LUA_PATH=${LUA_PATH}"
+  PASS_REGULAR_EXPRESSION "Job 4 exited with exit code 0"
+)
+
+add_test(
   NAME luzer_options_help_test
   COMMAND ${LUA_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_options_2.lua
           -help=1


### PR DESCRIPTION
The commit d777927e538b ("luzer: fix argv building") sets `argv[0]` to a constant value on the assumption that it is not used anywhere. But `argv[0]` is used in running a test by multiple processes. The patch fixes an `argv[0]` by setting it to a command and it's first argument with path to test.

Fixes #32