### PR TITLE
luzer: fix arguments checking in Fuzz()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   functions (#29).
 - Segmentation fault on tracing Lua source code (#18).
 - Arguments order in `consume_integers()` and `consume_numbers()` (#44).
+- Arguments checking in `Fuzz()` (#41).

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,19 +4,20 @@
 
 The `luzer` module provides a function `Fuzz()`.
 
-`Fuzz(test_one_input, custom_mutator, args)` starts the fuzzer. This function
-does not return.
+`Fuzz(test_one_input, [custom_mutator, [args]])` starts the fuzzer.
+This function does not return.
 
 Function accepts following arguments:
 
 - `test_one_input` is a fuzzer's entry point (equivalent to `TestOneInput`), it
   is a function that must take a single string argument. This will be repeatedly
   invoked with a single string container.
-- `custom_mutator` defines a custom mutator function (equivalent to
-  `LLVMFuzzerCustomMutator`). Default is `nil`.
-- `args` is a table with arguments: the process arguments to pass to the
+- `custom_mutator` (optional) defines a custom mutator function
+  (equivalent to `LLVMFuzzerCustomMutator`). Default is `nil`.
+- `args` (optional) is a table with arguments: the process arguments to pass to the
   fuzzer. Field `corpus` specifies a path to a directory with seed corpus, see a
   list with other options in the [libFuzzer documentation][libfuzzer-options-url].
+  Default is an empty table.
 
 It may be desirable to reject some inputs, i.e. to not add them to the corpus.
 For example, when fuzzing an API consisting of parsing and other logic, one may

--- a/luzer/init.lua
+++ b/luzer/init.lua
@@ -53,7 +53,16 @@ local function progname(argv)
 end
 
 local function Fuzz(test_one_input, custom_mutator, func_args)
-    local flags = build_flags(arg, func_args)
+    if custom_mutator ~= nil and
+       type(custom_mutator) ~= "function"
+    then
+        error("custom_mutator must be a function")
+    end
+    local luzer_args = func_args or {}
+    if type(luzer_args) ~= "table" then
+        error("args is not a table")
+    end
+    local flags = build_flags(arg, luzer_args)
     local test_path = arg[0]
     local lua_bin = progname(arg)
     local test_cmd = ("%s %s"):format(lua_bin, test_path)

--- a/luzer/tests/test_unit.lua
+++ b/luzer/tests/test_unit.lua
@@ -289,4 +289,25 @@ for _, testcase in ipairs(flag_testcases) do
     assert(val == res[2], ("expected %s"):format(val))
 end
 
+-- Call `Fuzz()` without arguments.
+ok, err = pcall(luzer.Fuzz)
+assert(ok == false)
+assert(err:match("test_one_input is not a Lua function") ~= nil)
+
+-- Call `Fuzz()` with a table instead TestOneInput function.
+ok, err = pcall(luzer.Fuzz, {})
+assert(ok == false)
+assert(err:match("test_one_input is not a Lua function") ~= nil)
+
+-- Call `Fuzz()` with a table instead a custom mutator function
+-- and a function instead a table with arguments.
+ok, err = pcall(luzer.Fuzz, function() end, {}, function() end)
+assert(ok == false)
+assert(err:match("custom_mutator must be a function") ~= nil)
+
+-- Call `Fuzz()` with a number instead a table with arguments.
+ok, err = pcall(luzer.Fuzz, function() end, nil, 42)
+assert(ok == false)
+assert(err:match("args is not a table") ~= nil)
+
 print("Success!")


### PR DESCRIPTION
Follows up commit 649289aa945b
("luzer: support command-line options").

Fixes #41