### PR TITLE
cmake: fix building in debug mode

### DIFF
--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -19,6 +19,20 @@ configure_file(
   @ONLY
 )
 
+add_compile_options(
+  -fpie
+  -fPIC
+  -pedantic
+  -Wall
+  -Werror
+  -Wextra
+  -Wno-unused-parameter
+  -Wpedantic
+)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_compile_options(-D_FORTIFY_SOURCE=2)
+endif()
+
 set(LUZER_SOURCES luzer.c
                   compat.c
                   fuzzed_data_provider.cc
@@ -38,15 +52,6 @@ target_link_libraries(luzer_impl PRIVATE
     ${FUZZER_NO_MAIN_LIBRARY}
 )
 target_compile_options(luzer_impl PRIVATE
-    -D_FORTIFY_SOURCE=2
-    -fpie
-    -fPIC
-    -Wall
-    -Wextra
-    -Werror
-    -Wpedantic
-    -Wno-unused-parameter
-    -pedantic
     -fsanitize=fuzzer-no-link
 )
 if(LUA_HAS_JIT)

--- a/luzer/luzer.h
+++ b/luzer/luzer.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-lua_State *get_global_lua_state();
+lua_State *get_global_lua_state(void);
 int luaL_mutate(lua_State *L);
 #ifdef __cplusplus
 } /* extern "C" */

--- a/luzer/tests/luac.c
+++ b/luzer/tests/luac.c
@@ -19,7 +19,7 @@ lua_say_hello(lua_State *L) {
 	say_hello(str, len);
 	lua_pop(L, 1);
 	return 0;
-};
+}
 
 static const struct luaL_Reg functions [] = {
 	{ "say_hello", lua_say_hello },

--- a/luzer/tests/test_lib.c
+++ b/luzer/tests/test_lib.c
@@ -13,6 +13,7 @@ say_hello(const char *buf, size_t len) {
 	} else if (mode && strcmp(mode, "NULL_POINTER_DEREF") == 0) {
 		const int *p1 = NULL;
 		int p2 = *p1;
+		(void)p2;
 	}
 	if (strncmp(buf, MESSAGE, len) == 0) {
 		fprintf(stderr, "%s\n", MESSAGE);


### PR DESCRIPTION
The build with -DCMAKE_BUILD_TYPE=Debug can ends with the error:

> In file included from luzer/counters.c:8:
> In file included from /usr/lib/llvm/20/bin/../../../../lib/clang/20/include/stdint.h:56:
> In file included from /usr/include/stdint.h:26:
> In file included from /usr/include/bits/libc-header-start.h:33:
> /usr/include/features.h:422:4: error: _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror,-W#warnings]
  422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)

This happened because _FORTIFY_SOURCE should be enabled along with non-zero optimization level. CMake has four build types: Release, Debug, RelWithDebInfo, MinSizeRel and only Debug build type disables optimizations. The patch applies C compiler hardening flags to all targets, enables `_FORTIFY_SOURCE` flags only for non-debug builds and fixes an error due to incorrect function prototype for `get_global_lua_state()`.

Fixes #54