### PR TITLE
luzer: fix compilation with the latest PUC Rio Lua

### DIFF
--- a/luzer/custom_mutator_lib.c
+++ b/luzer/custom_mutator_lib.c
@@ -12,13 +12,8 @@
 
 #include "luzer.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-int luaL_error(lua_State *L, const char *fmt, ...);
-size_t lua_objlen(lua_State *L, int index);
-#ifdef __cplusplus
-} /* extern "C" */
+#if LUA_VERSION_NUM == 501
+#define lua_rawlen(L, i) lua_objlen((L), (i))
 #endif
 
 size_t
@@ -31,7 +26,7 @@ LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
 	lua_pushinteger(L, seed);
 	luaL_mutate(L);
 
-	size_t sz = lua_objlen(L, -1);
+	size_t sz = lua_rawlen(L, -1);
 	if (sz > max_size)
 		luaL_error(L, "The size of mutated data cannot be larger than a max_size.");
 	const char *buf = lua_tostring(L, -1);


### PR DESCRIPTION
```
 /home/runner/work/lua-c-api-tests/lua-c-api-tests/build/luzer/source/luzer/custom_mutator_lib.c:19:33: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   19 | size_t lua_objlen(lua_State *L, int index);
      |                                 ^
/home/runner/work/lua-c-api-tests/lua-c-api-tests/build/luzer/source/luzer/custom_mutator_lib.c:19:8: error: conflicting types for 'lua_rawlen'
   19 | size_t lua_objlen(lua_State *L, int index);
      |        ^
/home/runner/work/lua-c-api-tests/lua-c-api-tests/build/lua-master/source/luaconf.h:357:26: note: expanded from macro 'lua_objlen'
  357 | #define lua_objlen(L,i)         lua_rawlen(L, (i))
      |                                 ^
/home/runner/work/lua-c-api-tests/lua-c-api-tests/build/lua-master/source/lua.h:204:26: note: previous declaration is here
  204 | LUA_API lua_Unsigned    (lua_rawlen) (lua_State *L, int idx);
      |                          ^
2 errors generated.
```