### PR TITLE
cmake: fix clang error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A memory leak in a Lua-based implementation of `TestOneInput()`.
 - An initial buffer size in FuzzedDataProvider.
 - Search of the archiver tool (`ar`) in the OSS Fuzz environment.
+- An error when Clang couldn't find the library.

--- a/cmake/BuildLibSanitizers.cmake
+++ b/cmake/BuildLibSanitizers.cmake
@@ -40,8 +40,8 @@ macro(GEN_BUILD_TARGET name libsanitizer_path libfuzzer_path
   set(LINK_COMMAND
     ${CMAKE_C_COMPILER}
     -Wl,--whole-archive
-    ${libfuzzer_name}
-    ${libsanitizer_name}
+    ${CMAKE_CURRENT_BINARY_DIR}/${libfuzzer_name}
+    ${CMAKE_CURRENT_BINARY_DIR}/${libsanitizer_name}
     -Wl,--no-whole-archive
     -lstdc++
     -lpthread
@@ -52,8 +52,8 @@ macro(GEN_BUILD_TARGET name libsanitizer_path libfuzzer_path
   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(LINK_COMMAND
       ${CMAKE_C_COMPILER}
-      ${libfuzzer_name}
-      ${libsanitizer_name}
+      ${CMAKE_CURRENT_BINARY_DIR}/${libfuzzer_name}
+      ${CMAKE_CURRENT_BINARY_DIR}/${libsanitizer_name}
       -lstdc++
       -lpthread
       -dynamiclib


### PR DESCRIPTION
Follows up the commit a0ecdf9ea96448d78ac8c9e095a92b5ad32f74f4 ("luzer: add macOS ARM64 support").

Fixes #87