### PR TITLE
luzer: suppress unsigned integer overflow in lhash()

### DIFF
--- a/luzer/macros.h
+++ b/luzer/macros.h
@@ -31,11 +31,15 @@
 #ifdef __has_attribute
 #if __has_attribute(no_sanitize)
 #define NO_SANITIZE_MEMORY __attribute__((no_sanitize("memory")))
+#define NO_SANITIZE_UNSIGNED_INT_OVERFLOW \
+  __attribute__((no_sanitize("unsigned-integer-overflow")))
 #else
 #define NO_SANITIZE_MEMORY
+#define NO_SANITIZE_UNSIGNED_INT_OVERFLOW
 #endif  // __has_attribute(no_sanitize)
 #else
 #define NO_SANITIZE_MEMORY
+#define NO_SANITIZE_UNSIGNED_INT_OVERFLOW
 #endif  // __has_attribute
 
 /*

--- a/luzer/tracer.c
+++ b/luzer/tracer.c
@@ -41,7 +41,7 @@ _trace_branch(uint64_t idx)
 	increment_counter(idx);
 }
 
-NO_SANITIZE static inline unsigned int
+NO_SANITIZE NO_SANITIZE_UNSIGNED_INT_OVERFLOW static inline unsigned int
 lhash(const char *key, size_t offset)
 {
 	const char *const last = &key[strlen(key) - 1];


### PR DESCRIPTION
The FNV-1a hash in lhash() uses uint32_t wrapping multiplication, which UBSan considers an error. The patch fixes the problem by adding a macro `NO_SANITIZE_UNSIGNED_INT_OVERFLOW`, which disables UBSan for unsigned integer overflow. It is applied to the function lhash(), where the FNV-1a hash intentionally uses uint32_t wrapping multiplication.

Fixes #86