### PR TITLE
luzer: print metrics only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An error when Clang couldn't find the library.
 - A possible corruption on copying library (#91).
 - A crash due to incorrect use of signal handler (#40).
+- Double printing metrics when using options -fork/-jobs (#89).

--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -43,13 +43,11 @@ add_compile_options(
   -Wno-unused-parameter
   -Wpedantic
 )
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # It turns out that macOS set _FORTIFY_SOURCE internally, so we
-  # need to undefine it first, otherwise an error "'_FORTIFY_SOURCE'
-  # macro redefined" breaks a building.
-  add_compile_options(-U_FORTIFY_SOURCE)
-  add_compile_options(-D_FORTIFY_SOURCE=2)
-endif()
+# _FORTIFY_SOURCE requires optimization (-O). When building without
+# optimization (Debug) or with -O0 (ASan/UBSan tests), glibc 2.40+
+# errors out. Since the toolchain may define _FORTIFY_SOURCE by
+# default (e.g. NixOS), undefine it unconditionally.
+add_compile_options(-U_FORTIFY_SOURCE)
 
 set(LUZER_SOURCES luzer.c
                   compat.c

--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -43,11 +43,13 @@ add_compile_options(
   -Wno-unused-parameter
   -Wpedantic
 )
-# _FORTIFY_SOURCE requires optimization (-O). When building without
-# optimization (Debug) or with -O0 (ASan/UBSan tests), glibc 2.40+
-# errors out. Since the toolchain may define _FORTIFY_SOURCE by
-# default (e.g. NixOS), undefine it unconditionally.
-add_compile_options(-U_FORTIFY_SOURCE)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # It turns out that macOS set _FORTIFY_SOURCE internally, so we
+  # need to undefine it first, otherwise an error "'_FORTIFY_SOURCE'
+  # macro redefined" breaks a building.
+  add_compile_options(-U_FORTIFY_SOURCE)
+  add_compile_options(-D_FORTIFY_SOURCE=2)
+endif()
 
 set(LUZER_SOURCES luzer.c
                   compat.c

--- a/luzer/init.lua
+++ b/luzer/init.lua
@@ -69,6 +69,9 @@ local function Fuzz(test_one_input, custom_mutator, func_args)
         error("args is not a table")
     end
     local flags = build_flags(arg, luzer_args)
+    if flags.fork or flags.jobs then
+        luzer_impl._set_fork_mode()
+    end
     local test_path = arg[0]
     local lua_bin = progname(arg)
     local test_cmd = ("%s %s"):format(lua_bin, test_path)

--- a/luzer/luzer.c
+++ b/luzer/luzer.c
@@ -11,6 +11,7 @@
 #ifdef LUA_HAS_JIT
 #include "luajit.h"
 #endif /* LUA_HAS_JIT */
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -50,12 +51,42 @@ static int jit_status = 0;
 #endif /* LUA_HAS_JIT && LUAJIT_FRIENDLY_MODE */
 
 int internal_hook_disabled = 0;
+static bool fork_mode = false;
+static bool fork_mode_main = false;
+static bool metrics_printed = false;
 
 #define LUA_SETHOOK(lua_state, hook, mask, count) \
 	do { \
 		if (!internal_hook_disabled) \
 			lua_sethook((lua_state), (hook), (mask), (count)); \
 	} while(0)
+
+/**
+ * Checks whether the current call is from the original (parent)
+ * process or from a forked child process. On first call, stores
+ * the current process PID. On subsequent calls, compares the
+ * stored PID with the current PID to detect fork().
+ *
+ * @return 1 - original (parent) process
+ *         0 - forked child process
+ */
+NO_SANITIZE static int
+check_parent_or_child(void)
+{
+	static pid_t saved_pid = -1;
+	static bool first_call = true;
+
+	if (first_call) {
+		saved_pid = getpid();
+		first_call = false;
+		return 1;
+	}
+
+	if (saved_pid == getpid())
+		return 1;
+	else
+		return 0;
+}
 
 NO_SANITIZE static void
 set_global_lua_state(lua_State *L)
@@ -266,6 +297,14 @@ luaL_set_custom_mutator(lua_State *L)
 }
 
 NO_SANITIZE static int
+luaL_set_fork_mode(lua_State *L)
+{
+	fork_mode = true;
+	fork_mode_main = true;
+	return 0;
+}
+
+NO_SANITIZE static int
 luaL_test_one_input(lua_State *L)
 {
 	lua_getglobal(L, TEST_ONE_INPUT_FUNC);
@@ -287,7 +326,20 @@ luaL_test_one_input(lua_State *L)
 __attribute__((destructor)) static void
 teardown(void)
 {
-	metrics_print();
+	/*
+	 * In single-process mode, print metrics from the destructor.
+	 * In fork/jobs mode, the main process prints metrics once:
+	 *   - from teardown() for -fork (exit() is called inside libFuzzer)
+	 *   - after LLVMFuzzerRunDriver() for -jobs (returns normally)
+	 * Child processes (fork/exec) always skip printing.
+	 */
+	if (fork_mode_main) {
+		if (!metrics_printed)
+			metrics_print();
+	} else if (!fork_mode) {
+		if (check_parent_or_child() == 1)
+			metrics_print();
+	}
 }
 
 NO_SANITIZE int
@@ -438,6 +490,17 @@ free_argv(int argc, char **argv)
 NO_SANITIZE static int
 luaL_fuzz(lua_State *L)
 {
+	/* Remember PID. */
+	check_parent_or_child();
+
+	/*
+	 * If LUZER_IN_FORK_MODE is set, this process is a child
+	 * spawned by libFuzzer's -jobs mode. Mark fork_mode without
+	 * setting fork_mode_main so children skip metrics printing.
+	 */
+	if (getenv("LUZER_IN_FORK_MODE"))
+		fork_mode = true;
+
 	const char *str = luaL_checkstring(L, -1);
 	lua_pop(L, 1);
 	char *argv_0 = strdup(str);
@@ -534,7 +597,27 @@ luaL_fuzz(lua_State *L)
 	jit_status = luajit_has_enabled_jit(L);
 #endif
 	set_global_lua_state(L);
+
+	/*
+	 * Set an environment variable so child processes spawned
+	 * via -jobs (which use exec, not fork) know they are
+	 * running in fork/jobs mode and should skip printing.
+	 */
+	if (fork_mode)
+		setenv("LUZER_IN_FORK_MODE", "1", 1);
+
 	int rc = LLVMFuzzerRunDriver(&argc, &argv, &TestOneInput);
+
+	/*
+	 * In -jobs mode, the main process returns here after all
+	 * child jobs have completed. Print metrics once.
+	 * In -fork mode, libFuzzer calls exit() inside FuzzWithFork,
+	 * so we never reach this point; printing happens in teardown().
+	 */
+	if (fork_mode_main) {
+		metrics_print();
+		metrics_printed = true;
+	}
 
 	free_argv(argc, argv);
 	luaL_cleanup(L);
@@ -548,6 +631,7 @@ static const struct luaL_Reg Module[] = {
 	{ "Fuzz", luaL_fuzz },
 	{ "FuzzedDataProvider", luaL_fuzzed_data_provider },
 	{ "_set_custom_mutator", luaL_set_custom_mutator },
+	{ "_set_fork_mode", luaL_set_fork_mode },
 	{ "_mutate", luaL_mutate },
 	{ NULL, NULL }
 };

--- a/luzer/tests/CMakeLists.txt
+++ b/luzer/tests/CMakeLists.txt
@@ -89,6 +89,34 @@ set_tests_properties(luzer_options_jobs_test PROPERTIES
   PASS_REGULAR_EXPRESSION "Job 4 exited with exit code 0"
 )
 
+set(LUAJIT_METRICS_MESSAGE "Total number of recorded traces")
+if (NOT LUAJIT_FRIENDLY_MODE)
+  set(LUAJIT_METRICS_MESSAGE "LuaJIT metrics disabled.")
+endif()
+add_test(
+  NAME luzer_options_jobs_metrics_test
+  COMMAND ${LUA_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_luajit_friendly.lua
+          -runs=100 -jobs=2
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(luzer_options_jobs_metrics_test PROPERTIES
+  ENVIRONMENT "DISABLE_LUAJIT_METRICS=1;LUA_CPATH=${LUA_CPATH};LUA_PATH=${LUA_PATH}"
+  FAIL_REGULAR_EXPRESSION "(${LUAJIT_METRICS_MESSAGE})(.*\\n.*\\1)+"
+)
+
+add_test(
+  NAME luzer_options_fork_metrics_test
+  COMMAND ${LUA_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_luajit_friendly.lua
+          -runs=100 -fork=1
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(luzer_options_fork_metrics_test PROPERTIES
+  ENVIRONMENT "DISABLE_LUAJIT_METRICS=1;LUA_CPATH=${LUA_CPATH};LUA_PATH=${LUA_PATH}"
+  FAIL_REGULAR_EXPRESSION "(${LUAJIT_METRICS_MESSAGE})(.*\\n.*\\1)+"
+)
+
 add_test(
   NAME luzer_options_help_test
   COMMAND ${LUA_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_options_2.lua

--- a/luzer/tests/CMakeLists.txt
+++ b/luzer/tests/CMakeLists.txt
@@ -215,8 +215,8 @@ macro(generate_luac_lib name cflags)
 endmacro()
 
 generate_luac_lib(luac "")
-generate_luac_lib(luac_asan "-fsanitize=address;-O0")
-generate_luac_lib(luac_ubsan "-fsanitize=undefined;-O0")
+generate_luac_lib(luac_asan "-fsanitize=address;-O1")
+generate_luac_lib(luac_ubsan "-fsanitize=undefined;-O1")
 
 macro(generate_luac_test name env_vars pass_regex)
   add_test(NAME ${name}
@@ -347,8 +347,8 @@ macro(generate_testlib name cflags)
 endmacro()
 
 generate_testlib(testlib "")
-generate_testlib(testlib_asan "-fsanitize=address;-O0")
-generate_testlib(testlib_ubsan "-fsanitize=undefined;-O0")
+generate_testlib(testlib_asan "-fsanitize=address;-O1")
+generate_testlib(testlib_ubsan "-fsanitize=undefined;-O1")
 
 macro(generate_ffi_test name env_vars pass_regex)
   add_test(

--- a/luzer/tests/CMakeLists.txt
+++ b/luzer/tests/CMakeLists.txt
@@ -243,8 +243,8 @@ macro(generate_luac_lib name cflags)
 endmacro()
 
 generate_luac_lib(luac "")
-generate_luac_lib(luac_asan "-fsanitize=address;-O1")
-generate_luac_lib(luac_ubsan "-fsanitize=undefined;-O1")
+generate_luac_lib(luac_asan "-fsanitize=address;-O0")
+generate_luac_lib(luac_ubsan "-fsanitize=undefined;-O0")
 
 macro(generate_luac_test name env_vars pass_regex)
   add_test(NAME ${name}
@@ -375,8 +375,8 @@ macro(generate_testlib name cflags)
 endmacro()
 
 generate_testlib(testlib "")
-generate_testlib(testlib_asan "-fsanitize=address;-O1")
-generate_testlib(testlib_ubsan "-fsanitize=undefined;-O1")
+generate_testlib(testlib_asan "-fsanitize=address;-O0")
+generate_testlib(testlib_ubsan "-fsanitize=undefined;-O0")
 
 macro(generate_ffi_test name env_vars pass_regex)
   add_test(

--- a/luzer/tests/test_luajit_friendly.lua
+++ b/luzer/tests/test_luajit_friendly.lua
@@ -1,13 +1,11 @@
 local luzer = require("luzer")
 
-local chunk = [[
 local function fib(n)
   if n <= 1 then
       return n
   end
   return fib(n - 1) + fib(n - 2)
 end
-]]
 
 local function TestOneInput(buf)
     local fdp = luzer.FuzzedDataProvider(buf)
@@ -24,7 +22,7 @@ local function TestOneInput(buf)
     end
 
     -- Needed for testing LuaJIT metric with parsed functions.
-    load(chunk)
+    fib(5)
 end
 
 local args = {

--- a/luzer/tests/test_luajit_friendly.lua
+++ b/luzer/tests/test_luajit_friendly.lua
@@ -14,7 +14,7 @@ local function TestOneInput(buf)
     local numbers = fdp:consume_numbers(0, 2*10^6, 10)
     for _, n in ipairs(numbers) do
         if n == 100500 then
-            assert("Bingo!")
+            error("Bingo!")
         end
     end
 


### PR DESCRIPTION
The function metrics_print() is called twice when `-fork`/`-jobs` are used. The reason is that `metrics_print()` is called from `__attribute__((destructor))`, and the destructor is executed in each forked process. When libFuzzer is run with the `-fork=N` or `-jobs=N` flags, it forks child processes. Each child process inherits the loaded shared library and its destructors.

The patch fixes that by adding a check to `metrics_print()` to skip printing if all metrics are zero (so the parent process with zeros won't print, but the child process with data will).

Fixes #89