### PR TITLE
luzer: fix a signal handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search of the archiver tool (`ar`) in the OSS Fuzz environment.
 - An error when Clang couldn't find the library.
 - A possible corruption on copying library (#91).
+- A crash due to incorrect use of signal handler (#40).

--- a/luzer/luzer.c
+++ b/luzer/luzer.c
@@ -209,8 +209,6 @@ NO_SANITIZE static void
 sig_handler(int sig)
 {
 	switch (sig) {
-	case SIGINT:
-		exit(0);
 	case SIGSEGV:
 		__sanitizer_print_stack_trace();
 		_exit(139);
@@ -521,8 +519,8 @@ luaL_fuzz(lua_State *L)
 	lua_pushboolean(L, 1);
 
 	struct sigaction act;
+	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_handler;
-	sigaction(SIGINT, &act, NULL);
 	sigaction(SIGSEGV, &act, NULL);
 
 	lua_getglobal(L, TEST_ONE_INPUT_FUNC);


### PR DESCRIPTION
The signal handler sometimes crashed, possibly because when using the -jobs=-1 option and a SIGINT was received, the luzer handler called `exit(0)`, which triggered destructors and killed the global `Fuzzer` object while the worker thread was still calling Fuzzer::InterruptExitCode().

The patch removes SIGINT handler because libFuzzer already has its own SIGINT handler (handle_int=1 by default), which correctly stops fuzzing via _Exit().

Also, the initialization of struct `sigaction` was added. Without zeroing, `sa_flags` contained garbage, which is undefined behavior.

Fixes #40