### PR TITLE
cmake: fix possible corruption on copying library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An initial buffer size in FuzzedDataProvider.
 - Search of the archiver tool (`ar`) in the OSS Fuzz environment.
 - An error when Clang couldn't find the library.
+- A possible corruption on copying library (#91).

--- a/cmake/BuildLibSanitizers.cmake
+++ b/cmake/BuildLibSanitizers.cmake
@@ -15,9 +15,8 @@ macro(GEN_BUILD_TARGET name libsanitizer_path libfuzzer_path
   get_filename_component(libfuzzer_name ${libfuzzer_path} NAME)
 
   add_custom_target(copy_libs_${name}
-    COMMENT "Copy libFuzzer and sanitizer libraries"
+    COMMENT "Copy sanitizer library ${name}"
     COMMAND ${CMAKE_COMMAND} -E copy ${libsanitizer_path} ${libsanitizer_name}
-    COMMAND ${CMAKE_COMMAND} -E copy ${libfuzzer_path} ${libfuzzer_name}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -66,6 +65,7 @@ macro(GEN_BUILD_TARGET name libsanitizer_path libfuzzer_path
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     BYPRODUCTS ${sanitizer_dso_name}
   )
+  add_dependencies(build_dso_${name} copy_libFuzzer)
   if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_dependencies(build_dso_${name} strip_lib_${name})
   else()
@@ -88,6 +88,14 @@ endif()
 
 set(ASAN_DSO "libfuzzer_with_asan${CMAKE_SHARED_LIBRARY_SUFFIX}")
 set(UBSAN_DSO "libfuzzer_with_ubsan${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+get_filename_component(FUZZER_NO_MAIN_LIB_NAME ${FUZZER_NO_MAIN_LIBRARY} NAME)
+add_custom_target(copy_libFuzzer
+  COMMENT "Copy libFuzzer library"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${FUZZER_NO_MAIN_LIBRARY} ${FUZZER_NO_MAIN_LIB_NAME}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 GEN_BUILD_TARGET("asan"
   ${LIBCLANG_ASAN_LIB}


### PR DESCRIPTION
Sometimes, when relinking the libFuzzer library with sanitizers, the following message appears:

> ld: libclang_rt.fuzzer_no_main.a: member \
> libclang_rt.fuzzer_no_main.a(fuzzer_no_main.o) in archive is not an object

A possible cause is a race condition for the shared file libclang_rt.fuzzer_no_main.a between two parallel targets. The GEN_BUILD_TARGET macro is called twice: for ASAN and for UBSAN. Each call creates a copy_libs_${name} target, which copies the same libclang_rt.fuzzer_no_main.a to a file at the same path. There is no dependency between `copy_libs_asan` and `copy_libs_ubsan`, so build tool runs them simultaneously. This can lead to a corrupted file (mixed data from two threads). GNU ld reads it and finds the fuzzer_no_main.o member, but its contents are invalid ELF, causing a build error.

The patch separates the copying of libclang_rt.fuzzer_no_main.a into a separate shared target, `copy_libFuzzer`, on which both `build_dso_asan` and `build_dso_ubsan` will depend. This eliminates concurrent writes. It removes the copying of the fuzzer library from copy_libs_{asan,ubsan}, so each one copies only its own sanitizer. It also adds the build_dso_{asan,ubsan} dependency to `copy_libFuzzer` so that the fuzzer library is copied before linking.

Fixes #91