### PR TITLE
ci: test with PUC Rio Lua 5.5

### DIFF
--- a/.github/actions/build-lua/action.yaml
+++ b/.github/actions/build-lua/action.yaml
@@ -1,0 +1,27 @@
+name: Build Lua from source
+description: Download and build a PUC Rio Lua version from source
+
+inputs:
+  version:
+    description: PUC Rio Lua version to build (e.g. 5.5.1)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download PUC Rio Lua tarball ${{ inputs.version }}
+      shell: bash
+      run: |
+        curl -fsSL -o lua-${{ inputs.version }}.tar.gz \
+          https://www.lua.org/ftp/lua-${{ inputs.version }}.tar.gz
+        tar -xzf lua-${{ inputs.version }}.tar.gz
+
+    - name: Build PUC Rio Lua ${{ inputs.version }}
+      shell: bash
+      working-directory: lua-${{ inputs.version }}
+      run: make linux MYCFLAGS=-fPIC -j$(getconf _NPROCESSORS_ONLN)
+
+    - name: Set CMake flags for PUC Rio Lua ${{ inputs.version }}
+      shell: bash
+      run: |
+        echo "LUACFLAGS=-DCMAKE_LUA_INCLUDE_DIR=$GITHUB_WORKSPACE/lua-${{ inputs.version }}/src -DCMAKE_LUA_LIBRARIES=$GITHUB_WORKSPACE/lua-${{ inputs.version }}/src/liblua.a -DLUA_EXECUTABLE=$GITHUB_WORKSPACE/lua-${{ inputs.version }}/src/lua" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,15 @@ jobs:
         os: [ubuntu-24.04, macos-26]
         BUILDTYPE: [Debug, Release]
         LIBLUA:
+          - "5.5"
           - "5.4"
           - "5.3"
           - "5.2"
           - "5.1"
           - "luajit-v2.1"
         exclude:
+          - os: macos-26
+            LIBLUA: "5.5"
           - os: macos-26
             LIBLUA: "5.4"
           - os: macos-26
@@ -34,6 +37,8 @@ jobs:
             CMAKEFLAGS: -DCMAKE_BUILD_TYPE=Debug
           - BUILDTYPE: Release
             CMAKEFLAGS: -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          - LIBLUA: "5.5"
+            PACKAGES: ""
           - LIBLUA: "5.4"
             PACKAGES: lua5.4 liblua5.4-dev
           - LIBLUA: "5.3"
@@ -62,12 +67,18 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install llvm luajit cmake ninja
 
+      - name: Build Lua 5.5 from source
+        if: matrix.LIBLUA == '5.5'
+        uses: ./.github/actions/build-lua
+        with:
+          version: 5.5.1
+
       - name: Running CMake (Linux)
         if: runner.os == 'Linux'
         run: >
           cmake -S . -B build -G Ninja -DENABLE_TESTING=ON
           -DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15
-          ${{ matrix.CMAKEFLAGS }} ${{ matrix.FLAVORFLAGS }}
+          ${{ matrix.CMAKEFLAGS }} ${{ matrix.FLAVORFLAGS }} ${{ env.LUACFLAGS }}
 
       - name: Define Brew prefixes (macOS)
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ENABLE_LUAJIT`, `LUAJIT_FRIENDLY_MODE` and `OSS_FUZZ`
   variables to the rockspec.
 - Support for building on i386 (#83).
+- Testing with PUC Rio Lua 5.5.
 
 ### Changed
 


### PR DESCRIPTION
PUC Rio Lua 5.5 was released, but the package is not available on Ubuntu, so the testing is missing. The patch adds an action that builds a Lua binary from source code and introduces testing with Lua 5.5 in test.yaml workflow.