### PR TITLE
fix: Lua coverage never reached libFuzzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An error when Clang couldn't find the library.
 - A possible corruption on copying library (#91).
 - A crash due to incorrect use of signal handler (#40).
+- Lua coverage was never passed to libFuzzer, so fuzzing ran without
+  feedback.

--- a/luzer/counters.c
+++ b/luzer/counters.c
@@ -69,10 +69,11 @@ NO_SANITIZE void
 increment_counter(size_t index)
 {
 	if (counters != NULL && pctable != NULL) {
-		// `counters` is an allocation of length `max_counters`. If we reserve more
-		// than the allocated number of counters, we'll wrap around and overload
-		// old counters, trading away fuzzing quality for limits on memory usage.
-		counters[counter_index % max_counters]++;
+		// `counters` is an allocation of length `max_counters`. The index is a
+		// hash of source:line from the debug hook, so it is folded into range
+		// here; distinct lines may collide, trading resolution for a fixed
+		// memory ceiling.
+		counters[index % max_counters]++;
 	}
 }
 
@@ -106,38 +107,40 @@ allocate_counters_and_pcs(void) {
 						"greater than the number of counters registered.\n");
 		_exit(1);
 	}
-	// Allocate memory.
-	if (counters == NULL || pctable == NULL) {
-		// We mmap memory for pctable and counters, instead of std::vector, ensuring
-		// that there is no initialization. The untouched memory will only cost
-		// virtual memory, which is cheap.
-		counters = (unsigned char*)(
-			mmap(NULL, max_counters, PROT_READ | PROT_WRITE,
-				 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
-			pctable = (struct PCTableEntry*)(
-					  mmap(NULL, max_counters * sizeof(struct PCTableEntry),
-						   PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
-		if (counters == MAP_FAILED || pctable == MAP_FAILED) {
-			fprintf(stderr, "Internal error: Failed to mmap counters.\n");
-			_exit(1);
-		}
+	if (counters != NULL && pctable != NULL) {
+		// The allocation was handed to libFuzzer on an earlier call.
+		return (counter_and_pc_table_range){NULL, NULL, NULL, NULL};
+	}
+	// We mmap memory for pctable and counters, instead of std::vector, ensuring
+	// that there is no initialization. The untouched memory will only cost
+	// virtual memory, which is cheap.
+	counters = (unsigned char*)(
+		mmap(NULL, max_counters, PROT_READ | PROT_WRITE,
+			 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
+	pctable = (struct PCTableEntry*)(
+		mmap(NULL, max_counters * sizeof(struct PCTableEntry),
+			 PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
+	if (counters == MAP_FAILED || pctable == MAP_FAILED) {
+		fprintf(stderr, "Internal error: Failed to mmap counters.\n");
+		_exit(1);
 	}
 
-	const size_t next_index = MIN(counter_index, max_counters);
-	if (counter_index_registered >= next_index) {
-		// There are no counters to pass. Perhaps because we've reserved more than
-		// max_counters, or because no counters have been reserved since this was
-		// last called.
-		counter_index_registered = counter_index;
-		return (counter_and_pc_table_range){NULL, NULL, NULL, NULL};
-	} else {
-		counter_and_pc_table_range ranges = {
-			.counters_start = counters + counter_index_registered,
-			.counters_end = counters + next_index,
-			.pctable_start = (uint8_t*)(pctable + counter_index_registered),
-			.pctable_end = (uint8_t*)(pctable + next_index)
-		};
-		counter_index_registered = counter_index;
-		return ranges;
-	}
+	// The debug hook addresses counters by a hash of source:line, so every
+	// bucket is live from the first execution: there is no reservation phase
+	// whose growth a registered range could follow. The whole allocation is
+	// handed to libFuzzer at once.
+	//
+	// The PC table goes with it. libFuzzer maps counters to PCs (the `cov:`
+	// statistic, -print_pcs, -print_funcs, -print_coverage) only while the
+	// number of registered counters equals the number of registered PC
+	// entries across all modules; registering counters alone would switch
+	// that off for native modules too. Lua lines have no machine address, so
+	// the entries stay zero, PC 0 with no function-entry flag, as in Atheris.
+	// They are never written, so the table costs virtual memory only.
+	return (counter_and_pc_table_range){
+		.counters_start = counters,
+		.counters_end = counters + max_counters,
+		.pctable_start = (unsigned char*)pctable,
+		.pctable_end = (unsigned char*)(pctable + max_counters)
+	};
 }

--- a/luzer/counters.c
+++ b/luzer/counters.c
@@ -43,7 +43,8 @@ test_only_reset_counters(void) {
 		counters = NULL;
 	}
 	if (pctable) {
-		munmap(pctable, max_counters);
+		// Same length this was mapped with.
+		munmap(pctable, max_counters * sizeof(struct PCTableEntry));
 		pctable = NULL;
 	}
 	max_counters = 0;

--- a/luzer/counters.c
+++ b/luzer/counters.c
@@ -24,12 +24,8 @@ void __sanitizer_cov_pcs_init(uint8_t* pcs_beg, uint8_t* pcs_end);
 
 static const size_t kDefaultNumCounters = 1 << 20;
 
-// Number of counters requested by Lua instrumentation.
-size_t counter_index = 0;
-// Number of counters given to Libfuzzer.
-size_t counter_index_registered = 0;
-// Maximum number of counters and pctable entries that may be reserved and also
-// the number that are allocated.
+// Number of counters and pctable entries that are allocated. Counter indices
+// are folded into this range by increment_counter.
 size_t max_counters = 0;
 // Counter Allocations. These are allocated once, before __sanitize_... are
 // called and can only be deallocated by test_only_reset_counters.
@@ -48,21 +44,6 @@ test_only_reset_counters(void) {
 		pctable = NULL;
 	}
 	max_counters = 0;
-	counter_index = 0;
-	counter_index_registered = 0;
-}
-
-NO_SANITIZE size_t
-reserve_counters(size_t amount) {
-	size_t ret = counter_index;
-	counter_index += amount;
-	return ret;
-}
-
-NO_SANITIZE size_t
-reserve_counter(void)
-{
-	return counter_index++;
 }
 
 NO_SANITIZE void
@@ -101,11 +82,6 @@ NO_SANITIZE counter_and_pc_table_range
 allocate_counters_and_pcs(void) {
 	if (max_counters < 1) {
 		set_max_counters(kDefaultNumCounters);
-	}
-	if (counter_index < counter_index_registered) {
-		fprintf(stderr, "Internal error: The counter index is "
-						"greater than the number of counters registered.\n");
-		_exit(1);
 	}
 	if (counters != NULL && pctable != NULL) {
 		// The allocation was handed to libFuzzer on an earlier call.

--- a/luzer/counters.c
+++ b/luzer/counters.c
@@ -22,7 +22,11 @@ void __sanitizer_cov_pcs_init(uint8_t* pcs_beg, uint8_t* pcs_end);
 } /* extern "C" */
 #endif
 
-static const size_t kDefaultNumCounters = 1 << 20;
+// libFuzzer derives 8 features from every counter and folds them into a
+// feature set of 2^21 entries, so counters 2^18 apart alias anyway. It also
+// clears and scans every registered counter on each execution, so a larger
+// table costs time on every run without adding resolution.
+static const size_t kDefaultNumCounters = 1 << 18;
 
 // Number of counters and pctable entries that are allocated. Counter indices
 // are folded into this range by increment_counter.

--- a/luzer/counters.h
+++ b/luzer/counters.h
@@ -7,18 +7,13 @@ struct PCTableEntry {
 };
 
 // Sets the global number of counters.
-// Must not be called after InitializeCountersWithLLVM is called.
+// Must not be called after allocate_counters_and_pcs is called.
 void set_max_counters(size_t max);
 
-// Returns the maximum number of allocatable luzer counters. If more than this
-// many counters are reserved, luzer reuses counters, lowering fuzz quality.
+// Returns the number of luzer counters. Indices at or beyond it are folded
+// into range by increment_counter, so distinct locations may share a counter,
+// lowering fuzz quality.
 size_t get_max_counters(void);
-
-// Returns a new counter index.
-size_t reserve_counter(void);
-// Reserves a number of counters with contiguous indices, and returns the first
-// index.
-size_t reserve_counters(size_t amount);
 
 // Increments the counter at the given index, folded modulo the maximum
 // number of counters.

--- a/luzer/counters.h
+++ b/luzer/counters.h
@@ -20,8 +20,8 @@ size_t reserve_counter(void);
 // index.
 size_t reserve_counters(size_t amount);
 
-// Increments a counter at the given index. If more than the maximum number of
-// counters has been reserved, reuse counters.
+// Increments the counter at the given index, folded modulo the maximum
+// number of counters.
 void increment_counter(size_t index);
 
 typedef struct counter_and_pc_table_range {
@@ -33,9 +33,8 @@ typedef struct counter_and_pc_table_range {
 
 // Returns pointers to a range of memory for counters and another for pctable.
 // The intent is for this memory to be handed to Libfuzzer. It will only be
-// deallocated by test_only_reset_counters. The size of the ranges is proportional
-// to the number of counters reserved, unless no new counters were reserved or
-// more than max_counters were already reserved, in which case returns nullptrs.
+// deallocated by test_only_reset_counters. The first call returns the whole
+// allocation, counters and PC table; every later call returns nullptrs.
 counter_and_pc_table_range allocate_counters_and_pcs(void);
 
 // Resets counters' state to defaults. This is not safe for use with the actual

--- a/luzer/tests/CMakeLists.txt
+++ b/luzer/tests/CMakeLists.txt
@@ -44,6 +44,18 @@ set_tests_properties(luzer_e2e_test PROPERTIES
 )
 
 add_test(
+  NAME luzer_coverage_feedback_test
+  COMMAND ${LUA_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_coverage.lua
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+# The test bounds itself by an execution budget; the timeout is a backstop.
+set_tests_properties(luzer_coverage_feedback_test PROPERTIES
+  ENVIRONMENT "LUA_CPATH=${LUA_CPATH};LUA_PATH=${LUA_PATH}"
+  PASS_REGULAR_EXPRESSION "coverage feedback reached the guarded branch"
+  TIMEOUT 600
+)
+
+add_test(
   NAME luzer_options_corpus_path_via_table_test
   COMMAND ${LUA_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_options_1.lua
           -max_total_time=1

--- a/luzer/tests/test_coverage.lua
+++ b/luzer/tests/test_coverage.lua
@@ -1,0 +1,32 @@
+local luzer = require("luzer")
+
+-- Four single-byte comparisons, nested so each one is a separate branch.
+--
+-- With coverage feedback libFuzzer solves them one byte at a time: each
+-- correct prefix is a new edge, the input is kept, and the next byte is
+-- brute-forced from there. Without feedback every input is independent
+-- and the whole 4-byte prefix has to land at once.
+--
+-- That gap is the test. test_e2e.lua compares a SINGLE byte, so it passes
+-- either way and cannot detect a broken coverage pipeline.
+local function TestOneInput(buf)
+    if #buf < 4 then return end
+    if buf:sub(1, 1) ~= "l" then return end
+    if buf:sub(2, 2) ~= "u" then return end
+    if buf:sub(3, 3) ~= "z" then return end
+    if buf:sub(4, 4) ~= "r" then return end
+    assert(nil, "coverage feedback reached the guarded branch")
+end
+
+-- The execution budget is the bound, pinned to a seed. With feedback the
+-- prefix is found after a few tens of thousands of executions under PUC
+-- Lua and a few hundred thousand under LuaJIT, so the budget leaves an
+-- order of magnitude of headroom. Without feedback it is exhausted in a
+-- few seconds at over a million executions per second, and the test
+-- fails. The CTest TIMEOUT is only a backstop.
+local opts = {
+    max_len = 64,
+    seed = 1,
+    runs = 4000000,
+}
+luzer.Fuzz(TestOneInput, nil, opts)


### PR DESCRIPTION
## Problem

Lua coverage never reached libFuzzer, so fuzzing Lua code was random input generation. Two independent causes, both in `luzer/counters.c`:

1. `increment_counter()` ignored its `index` argument and bumped `counters[counter_index]`, so every Lua line would have landed in one slot.
2. Nothing was ever registered. `allocate_counters_and_pcs()` only returned a range once `counter_index` had been advanced by `reserve_counter()`/`reserve_counters()`, which have no callers (they are left over from Atheris's model, where an instrumentation pass reserves an index per site; luzer hashes source:line in the debug hook instead). So `__sanitizer_cov_8bit_counters_init()` never ran, and libFuzzer warned "no interesting inputs were found so far".

## Change

- 7d2225f: unmap the PC table with the length it was mapped with (small independent fix).
- 3474027: index counters by the hash from the debug hook, and hand the whole table, counters and PC table, to libFuzzer once, on the call that maps it. The PC table matters: libFuzzer only maps counters to PCs (the `cov:` statistic, `-print_pcs`, `-print_funcs`, `-print_coverage`) while the counter and PC-entry counts match across all modules. Registering counters alone silences those for native modules too, and makes `-print_coverage` under the ASan preload report covered native functions as uncovered. The entries stay zero, as in Atheris; libFuzzer prints them as `NEW_PC: 0x1` and never dereferences them.
- 1a280da: drop the reservation API that nothing calls.
- 18fed2a: default table size 2^18. libFuzzer folds features into a 2^21 set with 8 per counter, so larger tables alias anyway, and it clears and scans every registered counter on each execution: 2^20 capped a trivial target at about 12K exec/s, 2^18 gives about 40K with the same resolution.
- b0fbb80: regression test. A 4-byte prefix that feedback solves one byte at a time; it passes in 0.6 s (PUC 5.1) and 6.5 s (LuaJIT), and against the old `counters.c` it exhausts its 4M-run budget in about 3 s and fails.

## Testing

Debian trixie, clang 19. Full suite: PUC-Rio Lua 5.1, 21 passed / 3 disabled; LuaJIT 2.1 with `LUAJIT_FRIENDLY_MODE`, 28 passed / 1 disabled. With an instrumented native module loaded, `-print_pcs` and `-print_coverage` output is the same as before the change, plus the Lua buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
